### PR TITLE
Added code to ignore PS3 dualshock 3 Motion Sensors device

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,4 +184,4 @@ add_subdirectory(docs)
 
 install(TARGETS moonlight DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES gamecontrollerdb.txt DESTINATION ${CMAKE_INSTALL_DATADIR}/moonlight)
-install(FILES moonlight.conf DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
+install(FILES moonlight.conf DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/moonlight)

--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -545,6 +545,19 @@ void evdev_create(const char* device, struct mapping* mappings, bool verbose, in
   } else
     strncpy((char*) &guid[2], name, 11);
 
+  if (strstr(name, "Motion Sensors"))
+  {
+    /* Don't use Dualshock 3 motion sensors device */
+    if (verbose)
+    {
+      fprintf(stderr, "ignoring dualshock 3 motion sensors device %s\n", name);
+      fflush(stderr);
+    }
+    libevdev_free(evdev);
+    close(fd);
+    return;
+  }
+
   char str_guid[33];
   char* buf = str_guid;
   for (int i = 0; i < 16; i++)

--- a/src/util.c
+++ b/src/util.c
@@ -29,7 +29,7 @@ int blank_fb(char *path, bool clear) {
   int fd = open(path, O_RDWR);
 
   if(fd >= 0) {
-    int ret = write(fd, clear ? "1" : "0", 1);
+    int ret = write(fd, clear ? "0" : "1", 1);
     if (ret < 0)
       fprintf(stderr, "Failed to clear framebuffer %s: %d\n", path, ret);
 


### PR DESCRIPTION
Additional device is breaking left trigger function in several applications.

**Description**
Motion sensors device generates a separate controller device that cuses left trigger to get stuck in several games.

**Purpose**
The changes check the evdev infos for the "Motion Sensors" string within device name (IDs for both evdev devices are identical) and ignore this evdev device.